### PR TITLE
Fixed id links

### DIFF
--- a/library.html
+++ b/library.html
@@ -82,7 +82,7 @@
                 <div class="tab-content bg-transparent" id="resourcesContent">
                   <div class="tab-pane fade show active" id="resources-game" role="tabpanel" aria-labelledby="resources-game-tab">
                       <!-- GAME RESOURCES AND TOOLS -->
-                      <h3>Game Resources and Tools</h3>
+                      <h3 id="game-resources-tools">Game Resources and Tools</h3>
 
                       <ul class="list-inline text-center">
                         <li class="list-inline-item"><a href="#majsoul">Mahjong Soul</a></li>
@@ -317,7 +317,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-strategy" role="tabpanel" aria-labelledby="resources-strategy-tab">
                       <!-- MAHJONG STRATEGY GUIDES AND BOOKS -->
-                      <h3>Mahjong Strategy Guides and Books</h3>
+                      <h3 id="mahj-strat">Mahjong Strategy Guides and Books</h3>
 
                       <ul class="list-inline text-center">
                         <li class="list-inline-item"><a href="#books">Books</a></li>
@@ -683,7 +683,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-gguides" role="tabpanel" aria-labelledby="resources-gguides-tab">
                       <!-- GENERAL GUIDES -->
-                      <h3>General Guides</h3>
+                      <h3 id="gen-guide">General Guides</h3>
 
                       <ul class="list-inline text-center">
                         <li class="list-inline-item"><a href="#mahjong">Mahjong</a></li>
@@ -791,7 +791,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-majplus" role="tabpanel" aria-labelledby="resources-majplus-tab">
                       <!-- MAJSOUL PLUS MODS -->
-                      <h3>Majsoul Plus Mods</h3>
+                      <h3 id="majsoulp-mods">Majsoul Plus Mods</h3>
 
                       <p><small>Please check the <a href="guides/Majsoul-Plus-Guide.html">Majsoul Plus Guide</a> if you don't know how to apply these.</small></p>
 
@@ -1200,7 +1200,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-media" role="tabpanel" aria-labelledby="resources-media-tab">
                       <!-- MOVIES AND OTHER MEDIA -->
-                      <h3>Movies and Other Media</h3>
+                      <h3 id="movs">Movies and Other Media</h3>
 
                       <ul class="list-inline text-center">
                         <li class="list-inline-item"><a href="#movienight">Movie Nights</a></li>
@@ -1358,7 +1358,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-mleague" role="tabpanel" aria-labelledby="resources-mleague-tab">
                       <!-- MLEAGUE CHANNELS -->
-                      <h3>M-league</h3>
+                      <h3 id="ml">M-league</h3>
 
                       <ul class="list-inline text-center">
                         <li class="list-inline-item"><a href="#res">Resources</a></li>
@@ -1545,7 +1545,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-mjg" role="tabpanel" aria-labelledby="resources-mjg-tab">
                       <!-- /mjg/ PROJECTS -->
-                      <h3>/mjg/ Projects</h3>
+                      <h3 id="proj">/mjg/ Projects</h3>
 
                       <table data-spy="scroll" class="table table-transparent table-bordered table-striped">
                         <thead class="thead-dark text-center">
@@ -1640,7 +1640,7 @@
                   </div>
                   <div class="tab-pane fade" id="resources-offline" role="tabpanel" aria-labelledby="resources-offline-tab">
                       <!-- OFFLINE GAME DOWNLOADS -->
-                      <h3>Offline Game Downloads</h3>
+                      <h3 id="luvnodocchi">Offline Game Downloads</h3>
 
                       <ul class="list-inline text-center">
                         <li class="list-inline-item"><a href="#games">Games</a></li>


### PR DESCRIPTION
Added the id links from the Repo's front page to the `<h3>` header tags in the library. Very strange why only the Library page has this problem. If it breaks something then sorry.